### PR TITLE
fix: many to many table name

### DIFF
--- a/src/util/extract-many-to-many-models/index.ts
+++ b/src/util/extract-many-to-many-models/index.ts
@@ -35,7 +35,7 @@ const generateModels = (
 
 	manyToManyTables.push({
 		dbName: `_${manyFirst.relationName}`,
-		name: manyFirst.relationName || '',
+		name: `${manySecond.type}To${manyFirst.type}`,
 		primaryKey: null,
 		uniqueFields: [],
 		uniqueIndexes: [],


### PR DESCRIPTION
The name for manyToManyTable should be mapped to manyTableName otherwise this won't work. If you use the below schema.

```prisma

generator client {
  provider      = "prisma-client-js"
  binaryTargets = ["native", "debian-openssl-1.1.x"]
}

datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
} 

model Post {
  id         Int        @id @default(autoincrement())
  title      String
  categories Category[] @relation("PC", map: "PC")
}

model Category {
  id    Int    @id @default(autoincrement())
  name  String
  posts Post[] @relation("PC", map: "PC")
}
```
without fix 
```typescript
import { relations } from 'drizzle-orm'
import { foreignKey, integer, pgTable, serial, text } from 'drizzle-orm/pg-core'

export const Post = pgTable('Post', {
	id: serial('id').notNull().primaryKey(),
	title: text('title').notNull()
});

export const Category = pgTable('Category', {
	id: serial('id').notNull().primaryKey(),
	name: text('name').notNull()
});

export const PC = pgTable('_PC', {
	PostId: integer('A').notNull(),
	CategoryId: integer('B').notNull()
}, (PC) => ({
	'_PC_Post_fkey': foreignKey({
		name: '_PC_Post_fkey',
		columns: [PC.PostId],
		foreignColumns: [Post.id]
	})
		.onDelete('cascade')
		.onUpdate('cascade'),
	'_PC_Category_fkey': foreignKey({
		name: '_PC_Category_fkey',
		columns: [PC.CategoryId],
		foreignColumns: [Category.id]
	})
		.onDelete('cascade')
		.onUpdate('cascade')
}));

export const PostRelations = relations(Post, ({ many }) => ({
	categories: many(CategoryToPost, {
		relationName: 'PostToCategoryToPost'
	})
}));

export const CategoryRelations = relations(Category, ({ many }) => ({
	posts: many(CategoryToPost, {
		relationName: 'CategoryToCategoryToPost'
	})
}));

export const PCRelations = relations(PC, ({ one }) => ({
	Post: one(Post, {
		relationName: 'PostToCategoryToPost',
		fields: [PC.PostId],
		references: [Post.id]
	}),
	Category: one(Category, {
		relationName: 'CategoryToCategoryToPost',
		fields: [PC.CategoryId],
		references: [Category.id]
	})
}));
```

with fix:
```typescript
import { relations } from 'drizzle-orm'
import { foreignKey, integer, pgTable, serial, text } from 'drizzle-orm/pg-core'

export const Post = pgTable('Post', {
	id: serial('id').notNull().primaryKey(),
	title: text('title').notNull()
});

export const Category = pgTable('Category', {
	id: serial('id').notNull().primaryKey(),
	name: text('name').notNull()
});

export const PostToCategory = pgTable('_PC', {
	PostId: integer('A').notNull(),
	CategoryId: integer('B').notNull()
}, (PostToCategory) => ({
	'_PC_Post_fkey': foreignKey({
		name: '_PC_Post_fkey',
		columns: [PostToCategory.PostId],
		foreignColumns: [Post.id]
	})
		.onDelete('cascade')
		.onUpdate('cascade'),
	'_PC_Category_fkey': foreignKey({
		name: '_PC_Category_fkey',
		columns: [PostToCategory.CategoryId],
		foreignColumns: [Category.id]
	})
		.onDelete('cascade')
		.onUpdate('cascade')
}));

export const PostRelations = relations(Post, ({ many }) => ({
	categories: many(PostToCategory, {
		relationName: 'PostToCategoryToPost'
	})
}));

export const CategoryRelations = relations(Category, ({ many }) => ({
	posts: many(PostToCategory, {
		relationName: 'CategoryToCategoryToPost'
	})
}));

export const PostToCategoryRelations = relations(PostToCategory, ({ one }) => ({
	Post: one(Post, {
		relationName: 'PostToCategoryToPost',
		fields: [PostToCategory.PostId],
		references: [Post.id]
	}),
	Category: one(Category, {
		relationName: 'CategoryToCategoryToPost',
		fields: [PostToCategory.CategoryId],
		references: [Category.id]
	})
}));
```
