### PR TITLE
allow empty dbgenerated attribute

### DIFF
--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -82,8 +82,13 @@ const addColumnModifiers = (field: DMMF.Field, column: string) => {
 				}
 
 				if (value.name === 'dbgenerated') {
-					column = column + `.default(sql\`${s(value.args[0], '`')}\`)`;
-
+					if (value.args.length) {
+						column = column + `.default(sql\`${s(value.args[0], '`')}\`)`;	
+					} else {
+						// dbgenerated may be empty, to allow for GENERATED columns
+					    // See https://github.com/prisma/prisma/discussions/20077#discussioncomment-7649016
+						column = column + ".generatedAlwaysAs(sql`__dbgenerated_was_empty__`)";	
+					}
 					drizzleImports.add('sql');
 					break;
 				}

--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -86,7 +86,7 @@ const addColumnModifiers = (field: DMMF.Field, column: string) => {
 						column = column + `.default(sql\`${s(value.args[0], '`')}\`)`;	
 					} else {
 						// dbgenerated may be empty, to allow for GENERATED columns
-					    // See https://github.com/prisma/prisma/discussions/20077#discussioncomment-7649016
+					        // See https://github.com/prisma/prisma/discussions/20077#discussioncomment-7649016
 						column = column + ".generatedAlwaysAs(sql`__dbgenerated_was_empty__`)";	
 					}
 					drizzleImports.add('sql');


### PR DESCRIPTION
Some developers have added empty `dbgenerated()` attributes to their schema to support GENERATED columns in postgres. See https://github.com/prisma/prisma/discussions/20077

Prior to the changes in tjis PR, `drizzle-prisma-generator` will throw an error when `dbgenerated()` is empty.

```
Cannot read properties of undefined (reading 'replace')
```

The error message is largely unhelpful, because there isn't an easy way to get the stack-trace from the prisma cli. However by examining the code you can see that the dbgenerated handling expects there always to be an argument for this attribute. 

This change allows for empty dbgenerated attributes (no arg), and declares them as GENERATED columns. We use a dummy SQL for the generated expression, since we have no way of knowing the actual expression or value the developer actually used.