### PR TITLE
generate rqbv2 relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Automatically generate Drizzle schema from Prisma schema
 generator drizzle {
   provider = "drizzle-prisma-generator"
   output = "./src/schema.ts"
-  version = "v1"
+  relationsVersion = "v1"
 }
 ```
 :warning: - if output doesn't end with `.ts`, it will be treated like a folder, and schema will be generated to `schema.ts` inside of it.  
 :warning: - binary types in `MySQL`, `PostgreSQL` are not yet supported by `drizzle-orm`, therefore will throw an error.  
 :warning: - generator only supports `postgresql`, `mysql`, `sqlite` data providers, others will throw an error.  
-:warning: - currently the supported value for version is v1. if version is not provided, the relations file for rqbv2 is generated and saved inside the parent folder of `schema.ts` as `relations.ts`
+:warning: - currently the supported value for `relationsVersion` is v1. if `relationsVersion` is not provided, the relations file for rqbv2 is generated and saved inside the parent folder of `schema.ts` as `relations.ts`
 
 -  Install `drizzle-orm`: `pnpm add drizzle-orm`  
 -  Import schema from specified output file\folder  

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Automatically generate Drizzle schema from Prisma schema
 generator drizzle {
   provider = "drizzle-prisma-generator"
   output = "./src/schema.ts"
+  version = "v1"
 }
 ```
 :warning: - if output doesn't end with `.ts`, it will be treated like a folder, and schema will be generated to `schema.ts` inside of it.  
 :warning: - binary types in `MySQL`, `PostgreSQL` are not yet supported by `drizzle-orm`, therefore will throw an error.  
 :warning: - generator only supports `postgresql`, `mysql`, `sqlite` data providers, others will throw an error.  
+:warning: - currently the supported value for version is v1. if version is not provided, the relations file for rqbv2 is generated and saved inside the parent folder of `schema.ts` as `relations.ts`
 
 -  Install `drizzle-orm`: `pnpm add drizzle-orm`  
 -  Import schema from specified output file\folder  

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export const generator = generatorHandler({
 
 		recursiveWrite(schemaPath, schema);
 
-		if (options.generator.config['version'] == 'v1') {
+		if (options.generator.config['relationsVersion'] == 'v1') {
 			const relationsPath = folderPath.endsWith('.ts')
 				? folderPath
 				: path.join(folderPath, '/relations.ts');

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export const generator = generatorHandler({
 
 		recursiveWrite(schemaPath, schema);
 
-		if (options.generator.config['relationsVersion'] == 'v1') {
+		if (options.generator.config['relationsVersion'] !== 'v1') {
 			const relationsPath = folderPath.endsWith('.ts')
 				? folderPath
 				: path.join(folderPath, '/relations.ts');

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,24 +17,25 @@ export const generator = generatorHandler({
 	onGenerate: async (options) => {
 		const dbType = options.datasources[0]?.provider;
 
-		let output: string;
+		let schema: string;
+		let relations: string;
 
 		switch (dbType) {
 			case 'postgres':
 			case 'postgresql': {
-				output = generatePgSchema(options);
+				[schema, relations] = generatePgSchema(options);
 
 				break;
 			}
 
 			case 'mysql': {
-				output = generateMySqlSchema(options);
+				[schema, relations] = generateMySqlSchema(options);
 
 				break;
 			}
 
 			case 'sqlite': {
-				output = generateSQLiteSchema(options);
+				[schema, relations] = generateSQLiteSchema(options);
 
 				break;
 			}
@@ -58,7 +59,15 @@ export const generator = generatorHandler({
 			? folderPath
 			: path.join(folderPath, '/schema.ts');
 
-		recursiveWrite(schemaPath, output);
+		recursiveWrite(schemaPath, schema);
+
+		if (options.generator.config['version'] == 'v1') {
+			const relationsPath = folderPath.endsWith('.ts')
+				? folderPath
+				: path.join(folderPath, '/relations.ts');
+
+			recursiveWrite(relationsPath, relations);
+		}
 	},
 });
 

--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -230,7 +230,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.generator.config['relationsVersion'] == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['relationsVersion'] === 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -291,7 +291,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 
 	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
 
-	const schema = [importsStr, ...tables, ...(options.generator.config['relationsVersion'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+	const schema = [importsStr, ...tables, ...(options.generator.config['relationsVersion'] === 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
 
 	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -230,7 +230,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.generator.config['version'] == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['relationsVersion'] == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -291,7 +291,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 
 	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
 
-	const schema = [importsStr, ...tables, ...(options.generator.config['version'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+	const schema = [importsStr, ...tables, ...(options.generator.config['relationsVersion'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
 
 	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -2,6 +2,7 @@ import { s } from '@/util/escape';
 import { extractManyToManyModels } from '@/util/extract-many-to-many-models';
 import { UnReadonlyDeep } from '@/util/un-readonly-deep';
 import { type DMMF, GeneratorError, type GeneratorOptions } from '@prisma/generator-helper';
+import path from 'path';
 
 const mySqlImports = new Set<string>(['mysqlTable']);
 const drizzleImports = new Set<string>([]);
@@ -144,6 +145,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 
 	const tables: string[] = [];
 	const rqb: string[] = [];
+	const rqbv2: string[] = [];
 
 	for (const schemaTable of modelsWithImplicit) {
 		const tableDbName = s(schemaTable.dbName ?? schemaTable.name);
@@ -228,7 +230,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		drizzleImports.add('relations');
+		if (options.version == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -249,6 +251,19 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		const rqbRelation =
 			`export const ${schemaTable.name}Relations = relations(${schemaTable.name}, ({ ${argString} }) => ({\n${rqbFields}\n}));`;
 
+		const rqbv2Fields = relFields.map(field => {
+			const relName = s(field.relationName ?? '');
+			return `\t\t${field.name}: ${
+				field.relationFromFields?.length
+				? `r.one.${field.type}({\n\t\t\tfrom: r.${schemaTable.name}.${field.relationFromFields.at(0)},\n\t\t\tto: r.${field.type}.${
+				field.relationToFields?.at(0)},\n\t\t\talias: '${relName}'\n\t\t})`
+				: `r.many.${field.type}({\n\t\t\talias: '${relName}'\n\t\t})`
+			}`
+		}).join(',\n');
+
+		const rqbv2Relation = `\t${schemaTable.name}: {\n${ rqbv2Fields }\n\t}`
+		
+		rqbv2.push(rqbv2Relation);
 		rqb.push(rqbRelation);
 	}
 
@@ -265,7 +280,18 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 	let importsStr: string | undefined = [drizzleImportsStr, mySqlImportsStr].filter((e) => e !== undefined).join('\n');
 	if (!importsStr.length) importsStr = undefined;
 
-	const output = [importsStr, ...tables, ...rqb].filter((e) => e !== undefined).join('\n\n');
+	const schemaFileName = options.schemaPath ? path.basename(options.schemaPath, path.extname(options.schemaPath)) : 'schema'
 
-	return output;
+	let rqbv2Imports = [
+		`import { defineRelations } from "drizzle-orm";`,
+		`import * as schema from "./${schemaFileName}";`
+	];
+
+	const rqbv2Relations = `\nexport const relations = defineRelations(schema, (r) => ({\n${rqbv2.join(',\n')}\n}));` 
+
+	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
+
+	const schema = [importsStr, ...tables, ...(options.generator.config['version'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+
+	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -230,7 +230,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.version == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['version'] == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -250,7 +250,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.generator.config['relationsVersion'] == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['relationsVersion'] === 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -311,7 +311,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 
 	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
 
-	const schema = [importsStr, ...pgEnums, ...tables, ...(options.generator.config['relationsVersion'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+	const schema = [importsStr, ...pgEnums, ...tables, ...(options.generator.config['relationsVersion'] === 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
 
 	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -250,7 +250,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.version == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['version'] == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -250,7 +250,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.generator.config['version'] == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['relationsVersion'] == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -311,7 +311,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 
 	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
 
-	const schema = [importsStr, ...pgEnums, ...tables, ...(options.generator.config['version'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+	const schema = [importsStr, ...pgEnums, ...tables, ...(options.generator.config['relationsVersion'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
 
 	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -2,6 +2,7 @@ import { s } from '@/util/escape';
 import { extractManyToManyModels } from '@/util/extract-many-to-many-models';
 import { UnReadonlyDeep } from '@/util/un-readonly-deep';
 import { type DMMF, GeneratorError, type GeneratorOptions } from '@prisma/generator-helper';
+import path from 'path';
 
 const pgImports = new Set<string>();
 const drizzleImports = new Set<string>();
@@ -163,6 +164,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 
 	const tables: string[] = [];
 	const rqb: string[] = [];
+	const rqbv2: string[] = [];
 
 	for (const schemaTable of modelsWithImplicit) {
 		const tableDbName = s(schemaTable.dbName ?? schemaTable.name);
@@ -248,7 +250,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		drizzleImports.add('relations');
+		if (options.version == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -269,6 +271,19 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 		const rqbRelation =
 			`export const ${schemaTable.name}Relations = relations(${schemaTable.name}, ({ ${argString} }) => ({\n${rqbFields}\n}));`;
 
+		const rqbv2Fields = relFields.map(field => {
+			const relName = s(field.relationName ?? '');
+			return `\t\t${field.name}: ${
+				field.relationFromFields?.length
+				? `r.one.${field.type}({\n\t\t\tfrom: r.${schemaTable.name}.${field.relationFromFields.at(0)},\n\t\t\tto: r.${field.type}.${
+				field.relationToFields?.at(0)},\n\t\t\talias: '${relName}'\n\t\t})`
+				: `r.many.${field.type}({\n\t\t\talias: '${relName}'\n\t\t})`
+			}`
+		}).join(',\n');
+
+		const rqbv2Relation = `\t${schemaTable.name}: {\n${ rqbv2Fields }\n\t}`
+
+		rqbv2.push(rqbv2Relation);
 		rqb.push(rqbRelation);
 	}
 
@@ -285,7 +300,18 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 	let importsStr: string | undefined = [drizzleImportsStr, pgImportsStr].filter((e) => e !== undefined).join('\n');
 	if (!importsStr.length) importsStr = undefined;
 
-	const output = [importsStr, ...pgEnums, ...tables, ...rqb].filter((e) => e !== undefined).join('\n\n');
+	const schemaFileName = options.schemaPath ? path.basename(options.schemaPath, path.extname(options.schemaPath)) : 'schema'
 
-	return output;
+	let rqbv2Imports = [
+		`import { defineRelations } from "drizzle-orm";`,
+		`import * as schema from "./${schemaFileName}";`
+	];
+
+	const rqbv2Relations = `\nexport const relations = defineRelations(schema, (r) => ({\n${rqbv2.join(',\n')}\n}));` 
+
+	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
+
+	const schema = [importsStr, ...pgEnums, ...tables, ...(options.generator.config['version'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+
+	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -220,7 +220,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.generator.config['version'] == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['relationsVersion'] == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -280,7 +280,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
 
-	const schema = [importsStr, ...tables, ...(options.generator.config['version'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+	const schema = [importsStr, ...tables, ...(options.generator.config['relationsVersion'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
 
 	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -220,7 +220,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.generator.config['relationsVersion'] == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['relationsVersion'] === 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -280,7 +280,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
 
-	const schema = [importsStr, ...tables, ...(options.generator.config['relationsVersion'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+	const schema = [importsStr, ...tables, ...(options.generator.config['relationsVersion'] === 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
 
 	return [schema, relations] as [string, string];
 };

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -220,7 +220,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		if (options.version == 'v1') drizzleImports.add('relations');
+		if (options.generator.config['version'] == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -2,6 +2,7 @@ import { s } from '@/util/escape';
 import { extractManyToManyModels } from '@/util/extract-many-to-many-models';
 import { UnReadonlyDeep } from '@/util/un-readonly-deep';
 import { type DMMF, GeneratorError, type GeneratorOptions } from '@prisma/generator-helper';
+import path from 'path';
 
 const sqliteImports = new Set<string>(['sqliteTable']);
 const drizzleImports = new Set<string>([]);
@@ -133,6 +134,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 	const tables: string[] = [];
 	const rqb: string[] = [];
+	const rqbv2: string[] = [];
 
 	for (const schemaTable of modelsWithImplicit) {
 		const tableDbName = s(schemaTable.dbName ?? schemaTable.name);
@@ -218,7 +220,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 		tables.push(table);
 
 		if (!relFields.length) continue;
-		drizzleImports.add('relations');
+		if (options.version == 'v1') drizzleImports.add('relations');
 
 		const relationArgs = new Set<string>();
 		const rqbFields = relFields.map((field) => {
@@ -239,6 +241,19 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 		const rqbRelation =
 			`export const ${schemaTable.name}Relations = relations(${schemaTable.name}, ({ ${argString} }) => ({\n${rqbFields}\n}));`;
 
+		const rqbv2Fields = relFields.map(field => {
+			const relName = s(field.relationName ?? '');
+			return `\t\t${field.name}: ${
+				field.relationFromFields?.length
+				? `r.one.${field.type}({\n\t\t\tfrom: r.${schemaTable.name}.${field.relationFromFields.at(0)},\n\t\t\tto: r.${field.type}.${
+				field.relationToFields?.at(0)},\n\t\t\talias: '${relName}'\n\t\t})`
+				: `r.many.${field.type}({\n\t\t\talias: '${relName}'\n\t\t})`
+			}`
+		}).join(',\n');
+
+		const rqbv2Relation = `\t${schemaTable.name}: {\n${ rqbv2Fields }\n\t}`
+
+		rqbv2.push(rqbv2Relation);
 		rqb.push(rqbRelation);
 	}
 
@@ -254,8 +269,18 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 	let importsStr: string | undefined = [drizzleImportsStr, sqliteImportsStr].filter((e) => e !== undefined).join('\n');
 	if (!importsStr.length) importsStr = undefined;
+	const schemaFileName = options.schemaPath ? path.basename(options.schemaPath, path.extname(options.schemaPath)) : 'schema'
 
-	const output = [importsStr, ...tables, ...rqb].filter((e) => e !== undefined).join('\n\n');
+	let rqbv2Imports = [
+		`import { defineRelations } from "drizzle-orm";`,
+		`import * as schema from "./${schemaFileName}";`
+	];
 
-	return output;
+	const rqbv2Relations = `\nexport const relations = defineRelations(schema, (r) => ({\n${rqbv2.join(',\n')}\n}));` 
+
+	const relations = [...rqbv2Imports, rqbv2Relations].join('\n')
+
+	const schema = [importsStr, ...tables, ...(options.generator.config['version'] == 'v1' ? rqb : [])].filter((e) => e !== undefined).join('\n\n');
+
+	return [schema, relations] as [string, string];
 };


### PR DESCRIPTION
initial attempt at rqbv2 support. will also support v1 with the **version** option

`
generator drizzle {
  provider = "drizzle-prisma-generator"
  output = "./src/schema.ts"
  version = "v1"
}
`

currently if version is not provided or is not v1 it will generate for v2 and writes **schema** in **schema.ts** and **relations** in **relations.ts**.

feel free to modify and give suggestions.

Thank you