### PR TITLE
update deprecated declaration for 3rd parameter

### DIFF
--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -221,7 +221,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		}
 		const table = `export const ${schemaTable.name} = mysqlTable('${tableDbName}', {\n${
 			Object.values(columnFields).join(',\n')
-		}\n}${indexes.length ? `, (${schemaTable.name}) => ([\n${indexes.join(',\n')}\n])` : ''});`;
+		}\n}${indexes.length ? `, (${schemaTable.name}) => [\n${indexes.join(',\n')}\n]` : ''});`;
 
 		tables.push(table);
 

--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -185,7 +185,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 
 			mySqlImports.add('foreignKey');
 
-			return `\t'${fkeyName}': foreignKey({\n\t\tname: '${fkeyName}',\n\t\tcolumns: [${
+			return `\tforeignKey({\n\t\tname: '${fkeyName}',\n\t\tcolumns: [${
 				field.relationFromFields.map((rel) => `${schemaTable.name}.${rel}`).join(', ')
 			}],\n\t\tforeignColumns: [${field.relationToFields!.map((rel) => `${field.type}.${rel}`).join(', ')}]\n\t})${
 				deleteAction && deleteAction !== 'no action' ? `\n\t\t.onDelete('${deleteAction}')` : ''
@@ -201,9 +201,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 				const idxName = s(idx.name ?? `${schemaTable.name}_${idx.fields.join('_')}_key`);
 				// _key comes from Prisma, if their AI is to be trusted
 
-				return `\t'${
-					idx.name ? idxName : `${idxName.slice(0, idxName.length - 4)}_unique_idx`
-				}': uniqueIndex('${idxName}')\n\t\t.on(${idx.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')})`;
+				return `\tuniqueIndex('${idxName}')\n\t\t.on(${idx.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')})`;
 			});
 
 			indexes.push(...uniques);
@@ -215,7 +213,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 			const pk = schemaTable.primaryKey!;
 			const pkName = s(pk.name ?? `${schemaTable.name}_cpk`);
 
-			const pkField = `\t'${pkName}': primaryKey({\n\t\tname: '${pkName}',\n\t\tcolumns: [${
+			const pkField = `\tprimaryKey({\n\t\tname: '${pkName}',\n\t\tcolumns: [${
 				pk.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')
 			}]\n\t})`;
 
@@ -223,7 +221,7 @@ export const generateMySqlSchema = (options: GeneratorOptions) => {
 		}
 		const table = `export const ${schemaTable.name} = mysqlTable('${tableDbName}', {\n${
 			Object.values(columnFields).join(',\n')
-		}\n}${indexes.length ? `, (${schemaTable.name}) => ({\n${indexes.join(',\n')}\n})` : ''});`;
+		}\n}${indexes.length ? `, (${schemaTable.name}) => ([\n${indexes.join(',\n')}\n])` : ''});`;
 
 		tables.push(table);
 

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -241,7 +241,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 
 		const table = `export const ${schemaTable.name} = pgTable('${tableDbName}', {\n${
 			Object.values(columnFields).join(',\n')
-		}\n}${indexes.length ? `, (${schemaTable.name}) => ([\n${indexes.join(',\n')}\n])` : ''});`;
+		}\n}${indexes.length ? `, (${schemaTable.name}) => [\n${indexes.join(',\n')}\n]` : ''});`;
 
 		tables.push(table);
 

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -204,7 +204,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 
 			pgImports.add('foreignKey');
 
-			return `\t'${fkeyName}': foreignKey({\n\t\tname: '${fkeyName}',\n\t\tcolumns: [${
+			return `\tforeignKey({\n\t\tname: '${fkeyName}',\n\t\tcolumns: [${
 				field.relationFromFields.map((rel) => `${schemaTable.name}.${rel}`).join(', ')
 			}],\n\t\tforeignColumns: [${field.relationToFields!.map((rel) => `${field.type}.${rel}`).join(', ')}]\n\t})${
 				deleteAction && deleteAction !== 'no action' ? `\n\t\t.onDelete('${deleteAction}')` : ''
@@ -220,9 +220,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 				const idxName = s(idx.name ?? `${schemaTable.name}_${idx.fields.join('_')}_key`);
 				// _key comes from Prisma, if their AI is to be trusted
 
-				return `\t'${
-					idx.name ? idxName : `${idxName.slice(0, idxName.length - 4)}_unique_idx`
-				}': uniqueIndex('${idxName}')\n\t\t.on(${idx.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')})`;
+				return `\tuniqueIndex('${idxName}')\n\t\t.on(${idx.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')})`;
 			});
 
 			indexes.push(...uniques);
@@ -234,7 +232,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 			const pk = schemaTable.primaryKey!;
 			const pkName = s(pk.name ?? `${schemaTable.name}_cpk`);
 
-			const pkField = `\t'${pkName}': primaryKey({\n\t\tname: '${pkName}',\n\t\tcolumns: [${
+			const pkField = `\tprimaryKey({\n\t\tname: '${pkName}',\n\t\tcolumns: [${
 				pk.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')
 			}]\n\t})`;
 
@@ -243,7 +241,7 @@ export const generatePgSchema = (options: GeneratorOptions) => {
 
 		const table = `export const ${schemaTable.name} = pgTable('${tableDbName}', {\n${
 			Object.values(columnFields).join(',\n')
-		}\n}${indexes.length ? `, (${schemaTable.name}) => ({\n${indexes.join(',\n')}\n})` : ''});`;
+		}\n}${indexes.length ? `, (${schemaTable.name}) => ([\n${indexes.join(',\n')}\n])` : ''});`;
 
 		tables.push(table);
 

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -174,7 +174,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 			sqliteImports.add('foreignKey');
 
-			return `\t'${fkeyName}': foreignKey({\n\t\tname: '${fkeyName}',\n\t\tcolumns: [${
+			return `\tforeignKey({\n\t\tname: '${fkeyName}',\n\t\tcolumns: [${
 				field.relationFromFields.map((rel) => `${schemaTable.name}.${rel}`).join(', ')
 			}],\n\t\tforeignColumns: [${field.relationToFields!.map((rel) => `${field.type}.${rel}`).join(', ')}]\n\t})${
 				deleteAction && deleteAction !== 'no action' ? `\n\t\t.onDelete('${deleteAction}')` : ''
@@ -190,9 +190,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 				const idxName = s(idx.name ?? `${schemaTable.name}_${idx.fields.join('_')}_key`);
 				// _key comes from Prisma, if their AI is to be trusted
 
-				return `\t'${
-					idx.name ? idxName : `${idxName.slice(0, idxName.length - 4)}_unique_idx`
-				}': uniqueIndex('${idxName}')\n\t\t.on(${idx.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')})`;
+				return `\tuniqueIndex('${idxName}')\n\t\t.on(${idx.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')})`;
 			});
 
 			indexes.push(...uniques);
@@ -204,7 +202,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 			const pk = schemaTable.primaryKey!;
 			const pkName = s(pk.name ?? `${schemaTable.name}_cpk`);
 
-			const pkField = `\t'${pkName}': primaryKey({\n\t\tname: '${pkName}',\n\t\tcolumns: [${
+			const pkField = `\tprimaryKey({\n\t\tname: '${pkName}',\n\t\tcolumns: [${
 				pk.fields.map((f) => `${schemaTable.name}.${f}`).join(', ')
 			}]\n\t})`;
 
@@ -213,7 +211,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 		const table = `export const ${schemaTable.name} = sqliteTable('${tableDbName}', {\n${
 			Object.values(columnFields).join(',\n')
-		}\n}${indexes.length ? `, (${schemaTable.name}) => ({\n${indexes.join(',\n')}\n})` : ''});`;
+		}\n}${indexes.length ? `, (${schemaTable.name}) => ([\n${indexes.join(',\n')}\n])` : ''});`;
 
 		tables.push(table);
 

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -211,7 +211,7 @@ export const generateSQLiteSchema = (options: GeneratorOptions) => {
 
 		const table = `export const ${schemaTable.name} = sqliteTable('${tableDbName}', {\n${
 			Object.values(columnFields).join(',\n')
-		}\n}${indexes.length ? `, (${schemaTable.name}) => ([\n${indexes.join(',\n')}\n])` : ''});`;
+		}\n}${indexes.length ? `, (${schemaTable.name}) => [\n${indexes.join(',\n')}\n]` : ''});`;
 
 		tables.push(table);
 


### PR DESCRIPTION


Addresses this issue https://github.com/drizzle-team/drizzle-prisma-generator/issues/16
Since [0.36.0](https://github.com/drizzle-team/drizzle-orm/releases/tag/0.36.0) third parameter became an array. Updated the code accordingly