### PR TITLE
import sql operator bug fix for sqlite db

### DIFF
--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -68,6 +68,8 @@ const addColumnModifiers = (field: DMMF.Field, column: string) => {
 
 				if (value.name === 'now') {
 					column = column + `.default(sql\`DATE('now')\`)`;
+
+					drizzleImports.add('sql');
 					break;
 				}
 


### PR DESCRIPTION
imports sql operator when setting default date

https://github.com/drizzle-team/drizzle-prisma-generator/blob/d7a5ab9238dae9957324e637c690c19ed06984c5/src/util/generators/sqlite.ts#L70