### PR TITLE
feat: add support for Drizzle's $onUpdate functionality with @updatedAt

### DIFF
--- a/src/util/generators/mysql.ts
+++ b/src/util/generators/mysql.ts
@@ -110,6 +110,11 @@ const addColumnModifiers = (field: DMMF.Field, column: string) => {
 		}
 	}
 
+	// Handle @updatedAt attribute - maps to Drizzle's $onUpdate functionality
+	if (field.isUpdatedAt) {
+		column = column + `.$onUpdate(() => new Date())`;
+	}
+
 	return column;
 };
 

--- a/src/util/generators/pg.ts
+++ b/src/util/generators/pg.ts
@@ -111,6 +111,11 @@ const addColumnModifiers = (field: DMMF.Field, column: string) => {
 		}
 	}
 
+	// Handle @updatedAt attribute - maps to Drizzle's $onUpdate functionality
+	if (field.isUpdatedAt) {
+		column = column + `.$onUpdate(() => new Date())`;
+	}
+
 	return column;
 };
 

--- a/src/util/generators/sqlite.ts
+++ b/src/util/generators/sqlite.ts
@@ -104,6 +104,11 @@ const addColumnModifiers = (field: DMMF.Field, column: string) => {
 		}
 	}
 
+	// Handle @updatedAt attribute - maps to Drizzle's $onUpdate functionality
+	if (field.isUpdatedAt) {
+		column = column + `.$onUpdate(() => new Date())`;
+	}
+
 	return column;
 };
 


### PR DESCRIPTION
## 🚀 Feature: Support for Drizzle's new `$onUpdate` functionality

This PR adds support for Drizzle ORM v0.30.5's new `$onUpdate` functionality by mapping Prisma's `@updatedAt` attribute to Drizzle's `$onUpdate(() => new Date())`.

### 📋 Changes

- **PostgreSQL Generator**: Maps `@updatedAt` to `.$onUpdate(() => new Date())`
- **MySQL Generator**: Maps `@updatedAt` to `.$onUpdate(() => new Date())`
- **SQLite Generator**: Maps `@updatedAt` to `.$onUpdate(() => new Date())`

### 🎯 Implementation Details

- Follows established codebase patterns for field modifier handling
- Consistent implementation across all three database generators
- Uses Prisma's native `field.isUpdatedAt` DMMF property
- Zero breaking changes to existing functionality
- Minimal code changes (3 lines per generator)

### 📖 Usage

**Prisma Schema:**
```prisma
model User {
  id        Int      @id @default(autoincrement())
  name      String
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt  // This will now use $onUpdate
}
```

**Generated Drizzle Schema:**
```typescript
export const User = pgTable('User', {
  id: serial('id').primaryKey(),
  name: text('name').notNull(),
  createdAt: timestamp('createdAt', { precision: 3 }).notNull().defaultNow(),
  updatedAt: timestamp('updatedAt', { precision: 3 }).notNull().$onUpdate(() => new Date())
});
```

### 🔗 Related

- Drizzle ORM v0.30.5 release: https://orm.drizzle.team/docs/latest-releases/drizzle-orm-v0305
- Drizzle `$onUpdate` documentation: https://orm.drizzle.team/docs/column-types/pg

### ✅ Testing

- All existing tests pass
- Build completes successfully
- Follows TypeScript strict mode requirements

This enhancement provides seamless integration between Prisma's `@updatedAt` attribute and Drizzle's new `$onUpdate` functionality, enabling automatic timestamp updates when records are modified.

